### PR TITLE
Release v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-fragment-mask",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "Mask GraphQL query result with Fragment",
   "repository": "https://github.com/izumin5210/graphql-fragment-mask.git",
   "homepage": "https://github.com/izumin5210/graphql-fragment-mask",


### PR DESCRIPTION

## 0.2.0 (2021-09-13)

#### :rocket: Enhancement
* [#11](https://github.com/izumin5210/graphql-fragment-mask/pull/11) Return null when input is null ([@izumin5210](https://github.com/izumin5210))
* [#8](https://github.com/izumin5210/graphql-fragment-mask/pull/8) Support (non-typed) `DocumentNode` ([@izumin5210](https://github.com/izumin5210))
* [#5](https://github.com/izumin5210/graphql-fragment-mask/pull/5) Improve typing and check types on test ([@izumin5210](https://github.com/izumin5210))

#### :memo: Documentation
* [#9](https://github.com/izumin5210/graphql-fragment-mask/pull/9) Update documents ([@izumin5210](https://github.com/izumin5210))

#### :house: Internal
* [#12](https://github.com/izumin5210/graphql-fragment-mask/pull/12) Fix typo in release script ([@izumin5210](https://github.com/izumin5210))
* [#10](https://github.com/izumin5210/graphql-fragment-mask/pull/10) Stop using lerna on release workflow ([@izumin5210](https://github.com/izumin5210))
* [#7](https://github.com/izumin5210/graphql-fragment-mask/pull/7) Setup release automation ([@izumin5210](https://github.com/izumin5210))
* [#6](https://github.com/izumin5210/graphql-fragment-mask/pull/6) Fix tsconfig for type-checking for tests ([@izumin5210](https://github.com/izumin5210))
* [#4](https://github.com/izumin5210/graphql-fragment-mask/pull/4) Call coveralls parallel-finished on CI ([@izumin5210](https://github.com/izumin5210))

#### Committers: 1
- Masayuki Izumi ([@izumin5210](https://github.com/izumin5210))