### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -46,9 +46,11 @@ runs:
         git show ${{ github.event.pull_request.base.sha }}:./CHANGELOG.md > tmp/CHANGELOG.base.md
         cat -s tmp/CHANGELOG.head.md tmp/CHANGELOG.base.md > CHANGELOG.md
         git checkout ${{ github.event.pull_request.head.ref }}
-        git add CHANGELOG.md
-        git commit -m "Update CHANGELOG for ${RELEASE_TAG}"
-        git push origin HEAD:${{ github.event.pull_request.head.ref }}
+        if git diff --name-only CHANGELOG.md | grep -q -e '^CHANGELOG.md$'; then
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG for ${RELEASE_TAG}"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+        fi
       env:
         RELEASE_TAG: ${{ steps.release-meta.outputs.tag }}
         RELEASE_NOTE: ${{ steps.release-meta.outputs.note }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   packages: write
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,23 @@
 
 #### Committers: 1
 - Masayuki Izumi ([@izumin5210](https://github.com/izumin5210))
+
+## 0.2.0 (2021-09-13)
+
+#### :rocket: Enhancement
+* [#11](https://github.com/izumin5210/graphql-fragment-mask/pull/11) Return null when input is null ([@izumin5210](https://github.com/izumin5210))
+* [#8](https://github.com/izumin5210/graphql-fragment-mask/pull/8) Support (non-typed) `DocumentNode` ([@izumin5210](https://github.com/izumin5210))
+* [#5](https://github.com/izumin5210/graphql-fragment-mask/pull/5) Improve typing and check types on test ([@izumin5210](https://github.com/izumin5210))
+
+#### :memo: Documentation
+* [#9](https://github.com/izumin5210/graphql-fragment-mask/pull/9) Update documents ([@izumin5210](https://github.com/izumin5210))
+
+#### :house: Internal
+* [#12](https://github.com/izumin5210/graphql-fragment-mask/pull/12) Fix typo in release script ([@izumin5210](https://github.com/izumin5210))
+* [#10](https://github.com/izumin5210/graphql-fragment-mask/pull/10) Stop using lerna on release workflow ([@izumin5210](https://github.com/izumin5210))
+* [#7](https://github.com/izumin5210/graphql-fragment-mask/pull/7) Setup release automation ([@izumin5210](https://github.com/izumin5210))
+* [#6](https://github.com/izumin5210/graphql-fragment-mask/pull/6) Fix tsconfig for type-checking for tests ([@izumin5210](https://github.com/izumin5210))
+* [#4](https://github.com/izumin5210/graphql-fragment-mask/pull/4) Call coveralls parallel-finished on CI ([@izumin5210](https://github.com/izumin5210))
+
+#### Committers: 1
+- Masayuki Izumi ([@izumin5210](https://github.com/izumin5210))


### PR DESCRIPTION

## 0.2.0 (2021-09-13)

#### :rocket: Enhancement
* [#11](https://github.com/izumin5210/graphql-fragment-mask/pull/11) Return null when input is null ([@izumin5210](https://github.com/izumin5210))
* [#8](https://github.com/izumin5210/graphql-fragment-mask/pull/8) Support (non-typed) `DocumentNode` ([@izumin5210](https://github.com/izumin5210))
* [#5](https://github.com/izumin5210/graphql-fragment-mask/pull/5) Improve typing and check types on test ([@izumin5210](https://github.com/izumin5210))

#### :memo: Documentation
* [#9](https://github.com/izumin5210/graphql-fragment-mask/pull/9) Update documents ([@izumin5210](https://github.com/izumin5210))

#### :house: Internal
* [#12](https://github.com/izumin5210/graphql-fragment-mask/pull/12) Fix typo in release script ([@izumin5210](https://github.com/izumin5210))
* [#10](https://github.com/izumin5210/graphql-fragment-mask/pull/10) Stop using lerna on release workflow ([@izumin5210](https://github.com/izumin5210))
* [#7](https://github.com/izumin5210/graphql-fragment-mask/pull/7) Setup release automation ([@izumin5210](https://github.com/izumin5210))
* [#6](https://github.com/izumin5210/graphql-fragment-mask/pull/6) Fix tsconfig for type-checking for tests ([@izumin5210](https://github.com/izumin5210))
* [#4](https://github.com/izumin5210/graphql-fragment-mask/pull/4) Call coveralls parallel-finished on CI ([@izumin5210](https://github.com/izumin5210))

#### Committers: 1
- Masayuki Izumi ([@izumin5210](https://github.com/izumin5210))